### PR TITLE
Make email display in footer and contact us page configurable

### DIFF
--- a/ps_contactinfo-rich.tpl
+++ b/ps_contactinfo-rich.tpl
@@ -51,17 +51,4 @@
       d='Modules.Contactinfo.Shop'
     }
   {/if}
-  {if $contact_infos.email}
-    <br>
-    {* First tag [1][/1] is for a HTML tag. *}
-    {l
-      s='Email us: [1]%email%[/1]'
-      sprintf=[
-        '[1]' => '<span>',
-        '[/1]' => '</span>',
-        '%email%' => $contact_infos.email
-      ]
-      d='Modules.Contactinfo.Shop'
-    }
-  {/if}
 </div>

--- a/ps_contactinfo-rich.tpl
+++ b/ps_contactinfo-rich.tpl
@@ -51,4 +51,17 @@
       d='Modules.Contactinfo.Shop'
     }
   {/if}
+  {if $contact_infos.email && $display_email}
+    <br>
+    {* First tag [1][/1] is for a HTML tag. *}
+    {l
+      s='Email us: [1]%email%[/1]'
+      sprintf=[
+        '[1]' => '<span>',
+        '[/1]' => '</span>',
+        '%email%' => $contact_infos.email
+      ]
+      d='Modules.Contactinfo.Shop'
+    }
+  {/if}
 </div>

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -120,7 +120,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
     public function getContent()
     {
-        $output = '';
+        $output = [];
 
         if (Tools::isSubmit('submitContactInfo')) {
             Configuration::updateValue('PS_CONTACT_INFO_DISPLAY_EMAIL', (int)Tools::getValue('PS_CONTACT_INFO_DISPLAY_EMAIL'));
@@ -129,7 +129,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 $this->_clearCache($template);
             }
 
-            $output .= $this->displayConfirmation($this->trans('Settings updated.', array(), 'Admin.Notifications.Success'));
+            $output[] = $this->displayConfirmation($this->trans('Settings updated.', array(), 'Admin.Notifications.Success'));
 
             Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true).'&conf=6&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name);
         }
@@ -157,7 +157,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
         $helper->fields_value['PS_CONTACT_INFO_DISPLAY_EMAIL'] = Configuration::get('PS_CONTACT_INFO_DISPLAY_EMAIL');
 
-        return $output.$helper->generateForm(array(
+        $output[] = $helper->generateForm(array(
             array(
                 'form' => array(
                     'legend' => array(
@@ -171,5 +171,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 )
             )
         ));
+
+        return implode($output);
     }
 }

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -42,7 +42,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $this->name = 'ps_contactinfo';
         $this->author = 'PrestaShop';
-        $this->version = '3.0.0';
+        $this->version = '3.1.0';
 
         $this->bootstrap = true;
         parent::__construct();
@@ -55,13 +55,13 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     public function install()
     {
         return parent::install()
+            && Configuration::updateValue('PS_CONTACT_INFO_DISPLAY_EMAIL', 1)
             && $this->registerHook([
                 'displayNav', // Standard hook
                 'displayNav1', // For Classic-inspired themes
                 'displayFooter',
                 'actionAdminStoresControllerUpdate_optionsAfter',
-            ])
-        ;
+            ]);
     }
 
     public function renderWidget($hookName = null, array $configuration = [])
@@ -105,6 +105,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
         return [
             'contact_infos' => $contact_infos,
+            'display_email' => Configuration::get('PS_CONTACT_INFO_DISPLAY_EMAIL'),
         ];
     }
 
@@ -115,5 +116,60 @@ class Ps_Contactinfo extends Module implements WidgetInterface
         }
 
         return true;
+    }
+
+    public function getContent()
+    {
+        $output = '';
+
+        if (Tools::isSubmit('submitContactInfo')) {
+            Configuration::updateValue('PS_CONTACT_INFO_DISPLAY_EMAIL', (int)Tools::getValue('PS_CONTACT_INFO_DISPLAY_EMAIL'));
+
+            foreach ($this->templates as $template) {
+                $this->_clearCache($template);
+            }
+
+            $output .= $this->displayConfirmation($this->trans('Settings updated.', array(), 'Admin.Notifications.Success'));
+
+            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true).'&conf=6&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name);
+        }
+
+        $helper = new HelperForm();
+        $helper->submit_action = 'submitContactInfo';
+
+        $field = array(
+            'type' => 'switch',
+            'label' => $this->trans('Display email address', array(), 'Admin.Global'),
+            'name' => 'PS_CONTACT_INFO_DISPLAY_EMAIL',
+            'values' => array(
+                array(
+                    'id' => 'active_on',
+                    'value' => 1,
+                    'label' => $this->trans('yes', array(), 'Admin.Global')
+                ),
+                array(
+                    'id' => 'active_off',
+                    'value' => 0,
+                    'label' => $this->trans('no', array(), 'Admin.Global')
+                )
+            )
+        );
+
+        $helper->fields_value['PS_CONTACT_INFO_DISPLAY_EMAIL'] = Configuration::get('PS_CONTACT_INFO_DISPLAY_EMAIL');
+
+        return $output.$helper->generateForm(array(
+            array(
+                'form' => array(
+                    'legend' => array(
+                        'title' => $this->displayName,
+                        'icon' => 'icon-share'
+                    ),
+                    'input' => [$field],
+                    'submit' => array(
+                        'title' => $this->trans('Save', array(), 'Admin.Actions')
+                    )
+                )
+            )
+        ));
     }
 }

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -139,18 +139,18 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
         $field = array(
             'type' => 'switch',
-            'label' => $this->trans('Display email address', array(), 'Admin.Global'),
+            'label' => $this->trans('Display email address', array(), 'Admin.Actions'),
             'name' => 'PS_CONTACT_INFO_DISPLAY_EMAIL',
             'values' => array(
                 array(
                     'id' => 'active_on',
                     'value' => 1,
-                    'label' => $this->trans('yes', array(), 'Admin.Global')
+                    'label' => $this->trans('Yes', array(), 'Admin.Global')
                 ),
                 array(
                     'id' => 'active_off',
                     'value' => 0,
-                    'label' => $this->trans('no', array(), 'Admin.Global')
+                    'label' => $this->trans('No', array(), 'Admin.Global')
                 )
             )
         );

--- a/ps_contactinfo.tpl
+++ b/ps_contactinfo.tpl
@@ -48,17 +48,4 @@
         d='Modules.Contactinfo.Shop'
       }
     {/if}
-    {if $contact_infos.email}
-      <br>
-      {* First tag [1][/1] is for a HTML tag. *}
-      {l
-        s='Email: [1]%email%[/1]'
-        sprintf=[
-          '%email%' => $contact_infos.email,
-          '[1]' => '<a href="mailto:'|cat:$contact_infos.email|cat:'">',
-          '[/1]' => '</a>'
-        ]
-        d='Modules.Contactinfo.Shop'
-      }
-    {/if}
 </div>

--- a/ps_contactinfo.tpl
+++ b/ps_contactinfo.tpl
@@ -48,4 +48,17 @@
         d='Modules.Contactinfo.Shop'
       }
     {/if}
+    {if $contact_infos.email && $display_email}
+      <br>
+      {* First tag [1][/1] is for a HTML tag. *}
+      {l
+        s='Email: [1]%email%[/1]'
+        sprintf=[
+          '%email%' => $contact_infos.email,
+          '[1]' => '<a href="mailto:'|cat:$contact_infos.email|cat:'">',
+          '[/1]' => '</a>'
+        ]
+        d='Modules.Contactinfo.Shop'
+      }
+    {/if}
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | Make the display of email address in footer and contact page's left column configurable. 
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14416
| How to test?  | see #14416