### PR TITLE
add theme compatibility indication in configuration page

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -141,6 +141,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
             'type' => 'switch',
             'label' => $this->trans('Display email address', array(), 'Admin.Actions'),
             'name' => 'PS_CONTACT_INFO_DISPLAY_EMAIL',
+            'desc' => $this->trans('Your theme needs to be compatible with this feature', array(), 'Modules.Contactinfo.Admin'),
             'values' => array(
                 array(
                     'id' => 'active_on',


### PR DESCRIPTION
The possibility to hide/display the merchant's email address has to be compatible with the current theme. This PR indicates this below the configuration field.