### PR TITLE
Use rich template when widget is displayed in right column

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_contactinfo</name>
 	<displayName><![CDATA[Contact information]]></displayName>
-	<version><![CDATA[3.2.0]]></version>
+	<version><![CDATA[3.3.0]]></version>
 	<description><![CDATA[Allows you to display additional information about your store&#039;s customer service.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[front_office_features]]></tab>

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -72,7 +72,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
         if (preg_match('/^displayNav\d*$/', $hookName)) {
             $template_file = $this->templates['light'];
-        } elseif ($hookName == 'displayLeftColumn') {
+        } elseif ($hookName == 'displayLeftColumn' || $hookName == 'displayRightColumn') {
             $template_file = $this->templates['rich'];
         } else {
             $template_file = $this->templates['default'];

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -42,7 +42,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $this->name = 'ps_contactinfo';
         $this->author = 'PrestaShop';
-        $this->version = '3.2.0';
+        $this->version = '3.3.0';
 
         $this->bootstrap = true;
         parent::__construct();


### PR DESCRIPTION
In version 177 of PrestaShop a fix was made in the core to allow this module to be displayed as a widget in the right column, however the fix is forced to use `displayLeftColumn` because the module poorly handles the right column case (actually doesn't manage it at all)
See https://github.com/PrestaShop/PrestaShop/pull/16520

This PR aims for managing this use case properly in order to fix the core template