### PR TITLE
Fixed uninitialized string offset bug

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -87,6 +87,9 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $address = $this->context->shop->getAddress();
 
+		$is_state_multilang = isset(State::$definition['multilang']) && State::$definition['multilang']==true;
+		$state_name = (new State($address->id_state))->name;
+
         $contact_infos = [
             'company' => Configuration::get('PS_SHOP_NAME'),
             'address' => [
@@ -95,7 +98,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 'address2' => $address->address2,
                 'postcode' => $address->postcode,
                 'city' => $address->city,
-                'state' => (new State($address->id_state))->name[$this->context->language->id],
+                'state' => $is_state_multilang ? $state_name[$this->context->language->id] : $state_name,
                 'country' => (new Country($address->id_country))->name[$this->context->language->id],
             ],
             'phone' => Configuration::get('PS_SHOP_PHONE'),

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -88,7 +88,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
         $address = $this->context->shop->getAddress();
 
         $is_state_multilang = !empty(State::$definition['multilang']);
-		$state_name = (new State($address->id_state))->name;
+        $state_name = (new State($address->id_state))->name;
 
         $contact_infos = [
             'company' => Configuration::get('PS_SHOP_NAME'),

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -87,7 +87,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $address = $this->context->shop->getAddress();
 
-		$is_state_multilang = isset(State::$definition['multilang']) && State::$definition['multilang']==true;
+        $is_state_multilang = !empty(State::$definition['multilang']);
 		$state_name = (new State($address->id_state))->name;
 
         $contact_infos = [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | After changing the language from the language selector module the site crashed with the message "ContextErrorException; Notice: Uninitialised string offset: 7" in line 98 of the file ps_contactinfo.php. 
| Type         | bug fix
| BC breaks    | no
| Deprecations | no
| Fixed ticket | Fixes PrestaShop/Prestashop#18707.
| How to test  | From back office, in the contact information module, choose a State for your address with N number of characters, e.i. Maine with N equalling 5. Then from the language selector pick a language whose id on the ps_lang table exceeds N, e.i a language whose id on the database table is 6. If site loaded normally the issue was fixed.

**Details:**

It seems to be due to the State.php class from prestashop not having the variable `'multilang' => true ` by default as part of it's `$definition` static variable, such as the Country.php has, and the ps_state_lang table not being present on my upgraded version of prestashop 1.7.6.4. I also didn't find the ps_state_lang table on newly installed instances of prestashop 1.7.6.4. 

The error comes from line 98 of the file ps_contactinfo.php, where a string which is the State from the address is being accessed like an array with the id of the language chosen from the language selector.

Since State.php from the classes folder of prestashop1.7 does not have `'multilang' => true` as part of it's `$definition` static variable, and the ps_state_lang table not existing, this results in only a string being accessed with the id of the language chosen from the language selector. And if the id of the language is higher than the number of characters from the State string then the exception  "ContextErrorException; Notice: Uninitialised string offset: 7" is thrown.

To fix this, in the `getWidgetVariables` function where the error occurs I made sure that the string `(new State($address->id_state))->name` was only accessed like an array if `isset(State::$definition['multilang']) && State::$definition['multilang']==true`.

Note that if multilang is set to true on State.php then there also need to exit the table ps_state_lang.

Thank you, and please review the commit from this PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
