### PR TITLE
Add shop legal details to template

### DIFF
--- a/ps_contactinfo-rich.tpl
+++ b/ps_contactinfo-rich.tpl
@@ -65,7 +65,7 @@
       <div class="icon"><i class="material-icons">&#xE88E;</i></div>
       <div class="data">
         {l s='Details:' d='Modules.Contactinfo.Shop'}<br/>
-        {$contact_infos.details}
+        {$contact_infos.details|nl2br nofilter}
       </div>
     </div>
   {/if}

--- a/ps_contactinfo-rich.tpl
+++ b/ps_contactinfo-rich.tpl
@@ -63,16 +63,13 @@
     </div>
   {/if}
   {if $contact_infos.details}
-    <br>
-    {* First tag [1][/1] is for a HTML tag. *}
-    {l
-      s='Details: [1]%details%[/1]'
-      sprintf=[
-        '[1]' => '<span>',
-        '[/1]' => '</span>',
-        '%fax%' => $contact_infos.details
-      ]
-      d='Modules.Contactinfo.Shop'
-    }
+    <hr/>
+    <div class="block">
+      <div class="icon"><i class="material-icons">&#xE88E;</i></div>
+      <div class="data">
+        {l s='Details:' d='Modules.Contactinfo.Shop'}<br/>
+        {$contact_infos.details}
+      </div>
+    </div>
   {/if}
 </div>

--- a/ps_contactinfo-rich.tpl
+++ b/ps_contactinfo-rich.tpl
@@ -50,16 +50,13 @@
     </div>
   {/if}
   {if $contact_infos.email && $display_email}
-    <br>
-    {l s='Email us: ' d='Shop.Theme.Global'}
-    {mailto address={$contact_infos.email} encode="javascript"}
     <hr/>
     <div class="block">
       <div class="icon"><i class="material-icons">&#xE158;</i></div>
       <div class="data email">
         {l s='Email us:' d='Modules.Contactinfo.Shop'}<br/>
+        {mailto address=$contact_infos.email encode="javascript"}
       </div>
-      {mailto address=$contact_infos.email encode="javascript"}
     </div>
   {/if}
   {if $contact_infos.details}

--- a/ps_contactinfo-rich.tpl
+++ b/ps_contactinfo-rich.tpl
@@ -62,4 +62,17 @@
       {mailto address=$contact_infos.email encode="javascript"}
     </div>
   {/if}
+  {if $contact_infos.details}
+    <br>
+    {* First tag [1][/1] is for a HTML tag. *}
+    {l
+      s='Details: [1]%details%[/1]'
+      sprintf=[
+        '[1]' => '<span>',
+        '[/1]' => '</span>',
+        '%fax%' => $contact_infos.details
+      ]
+      d='Modules.Contactinfo.Shop'
+    }
+  {/if}
 </div>

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -101,6 +101,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
             'phone' => Configuration::get('PS_SHOP_PHONE'),
             'fax' => Configuration::get('PS_SHOP_FAX'),
             'email' => Configuration::get('PS_SHOP_EMAIL'),
+            'details' => Configuration::get('PS_SHOP_DETAILS'),
         ];
 
         return [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Legal information is not displayed on contact page, while there is a field for that in Prestashop settings.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#26809
| How to test?  | You need to test **without** an overriding TPL in `/themes/classic/modules/ps_contactinfo`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
