### PR TITLE
Fix trying to access array offset on value of type null

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -95,7 +95,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 'address2' => $address->address2,
                 'postcode' => $address->postcode,
                 'city' => $address->city,
-                'state' => (new State($address->id_state))->name[$this->context->language->id],
+                'state' => (!empty($address->id_state) ? (new State($address->id_state))->name[$this->context->language->id] : null),
                 'country' => (new Country($address->id_country))->name[$this->context->language->id],
             ],
             'phone' => Configuration::get('PS_SHOP_PHONE'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If your shop's home country does not have states, the module throws `Trying to access array offset on value of type null` errors in front office, because `$address->id_state` is 0 and it's trying to create a State from 0.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_contactinfo/pull/43#issuecomment-999386914
| How to test?  | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
