### PR TITLE
Add new hooks for the contact page

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -59,6 +59,9 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 'displayNav', // Standard hook
                 'displayNav1', // For Classic-inspired themes
                 'displayFooter',
+                'displayContactRightColumn',
+                'displayContactLeftColumn',
+                'displayContactContent',
                 'actionAdminStoresControllerUpdate_optionsAfter',
             ]);
     }
@@ -71,7 +74,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
         if (preg_match('/^displayNav\d*$/', $hookName)) {
             $template_file = $this->templates['light'];
-        } elseif ($hookName == 'displayLeftColumn' || $hookName == 'displayRightColumn') {
+        } elseif ($hookName == 'displayContactLeftColumn' || $hookName == 'displayContactRightColumn' || $hookName == 'displayLeftColumn' || $hookName == 'displayRightColumn') {
             $template_file = $this->templates['rich'];
         } else {
             $template_file = $this->templates['default'];

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -74,9 +74,10 @@ class Ps_Contactinfo extends Module implements WidgetInterface
 
         if (preg_match('/^displayNav\d*$/', $hookName)) {
             $template_file = $this->templates['light'];
-        } elseif ($hookName == 'displayContactLeftColumn' || $hookName == 'displayContactRightColumn' || $hookName == 'displayLeftColumn' || $hookName == 'displayRightColumn') {
+        } elseif (in_array($hookName, ['displayContactLeftColumn', 'displayContactRightColumn', 'displayLeftColumn', 'displayRightColumn'])) {
             $template_file = $this->templates['rich'];
         } else {
+          var_dump('test');
             $template_file = $this->templates['default'];
         }
 

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -77,7 +77,6 @@ class Ps_Contactinfo extends Module implements WidgetInterface
         } elseif (in_array($hookName, ['displayContactLeftColumn', 'displayContactRightColumn', 'displayLeftColumn', 'displayRightColumn'])) {
             $template_file = $this->templates['rich'];
         } else {
-          var_dump('test');
             $template_file = $this->templates['default'];
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We want to move widgets to regular hooks to make life easier for theme developers
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29198.
| Related PR | https://github.com/PrestaShop/classic-theme/pull/52
| How to test?      | Verify that the contact page is working properly. Make sure to test with https://github.com/PrestaShop/classic-theme/pull/52
| Possible impacts? | Contact page display

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
