### PR TITLE
shorten trans call

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -46,8 +46,8 @@ class Ps_Contactinfo extends Module implements WidgetInterface
         $this->bootstrap = true;
         parent::__construct();
 
-        $this->displayName = $this->getTranslator()->trans('Contact information', [], 'Modules.Contactinfo.Admin');
-        $this->description = $this->getTranslator()->trans('Let your customers know how to reach you, display contact information on your store.', [], 'Modules.Contactinfo.Admin');
+        $this->displayName = $this->trans('Contact information', [], 'Modules.Contactinfo.Admin');
+        $this->description = $this->trans('Let your customers know how to reach you, display contact information on your store.', [], 'Modules.Contactinfo.Admin');
         $this->ps_versions_compliancy = ['min' => '1.7.2.0', 'max' => _PS_VERSION_];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Module class has its own [trans](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L3363) function so we need to replace `getTranslator()->trans` by `trans` to keep consistency and briefness.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30193
| How to test?  | Nothing changes in module's behavior. Check the Module `trans` code in the above Description is the best way verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
