### PR TITLE
add missing hooks when upgrading from old versions

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_contactinfo</name>
 	<displayName><![CDATA[Contact information]]></displayName>
-	<version><![CDATA[3.3.1]]></version>
+	<version><![CDATA[3.3.2]]></version>
 	<description><![CDATA[Allows you to display additional information about your store&#039;s customer service.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[front_office_features]]></tab>

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -41,7 +41,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $this->name = 'ps_contactinfo';
         $this->author = 'PrestaShop';
-        $this->version = '3.3.1';
+        $this->version = '3.3.2';
 
         $this->bootstrap = true;
         parent::__construct();

--- a/upgrade/upgrade-3.3.2.php
+++ b/upgrade/upgrade-3.3.2.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_3_2($object)
+{
+    return $object->registerHook(['displayContactRightColumn', 'displayContactLeftColumn', 'displayContactContent']);
+}

--- a/upgrade/upgrade-3.3.2.php
+++ b/upgrade/upgrade-3.3.2.php
@@ -29,5 +29,5 @@ if (!defined('_PS_VERSION_')) {
 
 function upgrade_module_3_3_2($object)
 {
-    return $object->registerHook(['displayContactRightColumn', 'displayContactLeftColumn', 'displayContactContent']);
+    return $object->registerHook(['displayContactRightColumn', 'displayContactLeftColumn']);
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | To prevent issues with upgraded installations, we should hook this module during its upgrade.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Related to the contactform fix
| How to test?  | You'd need to have the version below < 3.3.1 installed to see that hooks are registered during an upgrade of the module.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
