### PR TITLE
Fix mod_fcgid: stderr: PHP Warning: Uninitialized string offset apach…

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -90,6 +90,16 @@ class Ps_Contactinfo extends Module implements WidgetInterface
         $address = $this->context->shop->getAddress();
         $formattedAddress = AddressFormat::generateAddress($address, [], '<br />');
 
+        $state = null;
+        if (!empty($address->id_state)) {
+            $stateObj = new State($address->id_state);
+            if (is_array($stateObj->name)) {
+                $state = $stateObj->name[$this->context->language->id] ?? '';
+            } else {
+                $state = $stateObj->name;
+            }
+        }
+
         $contact_infos = [
             'company' => Configuration::get('PS_SHOP_NAME'),
             'address' => [
@@ -98,7 +108,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 'address2' => $address->address2,
                 'postcode' => $address->postcode,
                 'city' => $address->city,
-                'state' => (!empty($address->id_state) ? (new State($address->id_state))->name[$this->context->language->id] : null),
+                'state' => $state,
                 'country' => (new Country($address->id_country))->name[$this->context->language->id],
             ],
             'phone' => Configuration::get('PS_SHOP_PHONE'),


### PR DESCRIPTION
This PR prevents a “PHP Warning: Uninitialized string offset” in the ps_contactinfo module by validating and normalizing the state name before use. Instead of indexing directly into a possibly non-existent array or string, we:

Initialize a safe $state variable to null.

If $address->id_state exists, load the State object and:

If its name property is an array, pick the current language entry (or fallback to '').

Otherwise, use the string value directly.

Finally, reference this validated $state when building the widget variables.

This removes the warning from Apache logs and ensures the front-office always sees a consistent, safe value.

How to test

In Back Office, configure a shop address without selecting a state, or with a state in any language.

Refresh the Front Office page where ps_contactinfo is hooked (e.g. footer).

Confirm no “Uninitialized string offset” warnings appear in:

Apache/PHP error log

PrestaShop debug log

Verify that the shop contact block still displays correctly, showing an empty string when no state is set.

Compatibility

✅ Fully compatible with PrestaShop 8.2.1 and earlier versions.

❌ No database schema changes.

⚙️ No external dependencies introduced.

Changelog

Added $state pre-validation in getWidgetVariables() to avoid direct string offset access.

Replaced inline (new State(...))->name[...] on line 104 with the validated $state variable.

