### PR TITLE
Remove displayContactContent hook

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_contactinfo</name>
 	<displayName><![CDATA[Contact information]]></displayName>
-	<version><![CDATA[3.3.3]]></version>
+	<version><![CDATA[3.3.4]]></version>
 	<description><![CDATA[Allows you to display additional information about your store&#039;s customer service.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[front_office_features]]></tab>

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -61,7 +61,6 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 'displayFooter',
                 'displayContactRightColumn',
                 'displayContactLeftColumn',
-                'displayContactContent',
                 'actionAdminStoresControllerUpdate_optionsAfter',
             ]);
     }

--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -41,7 +41,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $this->name = 'ps_contactinfo';
         $this->author = 'PrestaShop';
-        $this->version = '3.3.3';
+        $this->version = '3.3.4';
 
         $this->bootstrap = true;
         parent::__construct();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove the useless displayContactContent hook that was added by mistake a long time ago
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

As explained in this comment https://github.com/PrestaShop/hummingbird/pull/904#issuecomment-3776589941 the hook seems to have been added by mistake