### PR TITLE
Update version and fix state name retrieval

### DIFF
--- a/ps_contactinfo.php
+++ b/ps_contactinfo.php
@@ -41,7 +41,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
     {
         $this->name = 'ps_contactinfo';
         $this->author = 'PrestaShop';
-        $this->version = '3.3.3';
+        $this->version = '3.3.4';
 
         $this->bootstrap = true;
         parent::__construct();
@@ -98,7 +98,7 @@ class Ps_Contactinfo extends Module implements WidgetInterface
                 'address2' => $address->address2,
                 'postcode' => $address->postcode,
                 'city' => $address->city,
-                'state' => (!empty($address->id_state) ? (new State($address->id_state))->name[$this->context->language->id] : null),
+                'state' => (!empty($address->id_state) ? (new State($address->id_state))->name : null),
                 'country' => (new Country($address->id_country))->name[$this->context->language->id],
             ],
             'phone' => Configuration::get('PS_SHOP_PHONE'),


### PR DESCRIPTION
Updated version number from 3.3.3 to 3.3.4 and modified state retrieval logic to use the default name. the

Changing versions is necessary to apply fixes made in the past that aren't present in the stable version of PrestaShop. For example, I keep seeing these lines in 3.3.3.

$is_state_multilang = !empty(State::$definition['multilang']); $state_name = (new State($address->id_state))->name;

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In the previous version, the code attempted to access the state name as a localized array:@Maofree Could you please open a PR for the module? It is the easiest way to implement these changes. :-)<br/>`new State($address->id_state))->name[$this->context->language->id]`<br/>However, in current PrestaShop core versions, the State::$name property is not a multilang field. This caused issues (Notice or Error depending on environment) when trying to display contact information in the footer/widget. The logic has been simplified to use the direct property.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31792
| How to test?  | Enable the module to display in the footer or contact page. Observe that without this fix, the state name might not appear correctly or trigger an "Illegal offset" warning if error reporting is on. die(var_dump((new State($address->id_state))->name)); I can see "Italia" instead with (new State($address->id_state))->name I see "i"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
